### PR TITLE
add commandline args explanation for mcp

### DIFF
--- a/mcp-servers/apps-server.mdx
+++ b/mcp-servers/apps-server.mdx
@@ -129,3 +129,42 @@ Before using the `Apps MCP Server`, you need to complete several setup steps on 
     ```
   </Accordion>
 </AccordionGroup>
+
+## Commandline Arguments
+
+<AccordionGroup>
+  <Accordion title="[Required] --apps">
+    The `apps` argument is used to specify the apps you want to use with your MCP server. E.g., `--apps GMAIL,BRAVE,GITHUB` means that the MCP server will only access and expose the functions (tools) from `GMAIL`, `BRAVE` and `GITHUB` apps.
+    <Note>
+      The apps must be configured and enabled first.
+    </Note>
+  </Accordion>
+  <Accordion title="[Required] --linked-account-owner-id">
+    The `linked-account-owner-id` is the owner ID of the linked accounts you want to use for the function execution. E.g., `--linked-account-owner-id johndoe` means that the function execution (e.g, `GMAIL__SEND_EMAIL`) will be done on behalf of the linked account of `GMAIL` app with owner ID `johndoe`.
+  </Accordion>
+  <Accordion title="[Optional] --transport">
+    The `transport` argument is used to specify the transport protocol to use for the MCP server.
+    The default transport is `stdio`.
+  </Accordion>
+  <Accordion title="[Optional] --port">
+    The `port` argument is used to specify the port to listen on for the MCP server if the `--transport` is set to `sse`.
+    The default port is `8000`.
+  </Accordion>
+</AccordionGroup>
+
+```bash help
+$ uvx aci-mcp apps-server --help
+Usage: aci-mcp apps-server [OPTIONS]
+
+  Start the apps-specific MCP server to access tools under specific apps.
+
+Options:
+  --apps TEXT                     comma separated list of apps of which to use
+                                  the functions  [required]
+  --linked-account-owner-id TEXT  the owner id of the linked accounts to use
+                                  for the tool calls. You'll need to create
+                                  the linked accounts on platform.aci.dev
+                                  [required]
+  --transport [stdio|sse]         Transport type
+  --port INTEGER                  Port to listen on for SSE
+  --help                          Show this message and exit.

--- a/mcp-servers/introduction.mdx
+++ b/mcp-servers/introduction.mdx
@@ -14,13 +14,24 @@ The codebase is open source and can be found here: [aci-mcp <Icon icon="up-right
 - **Apps MCP Server**: This server is similar to most of the existing MCP servers out there, where it exposes a set of functions from a specific app (e.g., Gmail, Github, etc.). However, our `Apps MCP Server` allows you to include multiple apps in a single server.
 - **Unified MCP Server**: This server is a dynamic server that provides two meta functions (tools) to discover and execute ANY functions (tools) available on ACI.dev platform.
 
-For pros and cons of each server, please refer to the individual sections.
+## Comparison
 
+- **When to use the Apps MCP Server?**
+  - When you know exactly what apps the LLM/Agent needs in advance.
+  - When the number of apps, and therefore the associated functions, needed is relatively small. 
+    <Note>
+      There is no definitive answer to `what number of functions (tools) is too many?`, but the more functions (tools) you add to the model's context window, the lower the performance of the LLM function calling.
+    </Note>
+
+- **When to use the Unified MCP Server?**
+  - When you don't know exactly what apps the LLM/Agent needs in advance.
+  - When the number of apps and therefore the associated functions needed is large.
+  - When you want all future apps added to ACI.dev to be discoverable by your LLM/Agent without having to update the MCP command.
 
 
 ## Next Steps
 
-Choose the MCP server that best fits your needs and follow the instructions in the respective sections.
+Choose the MCP server that best fits your needs and follow the instructions in the respective sections to set it up.
 <CardGroup cols={2}>
   <Card title="Unified MCP Server" icon="circle-nodes" href="/mcp-servers/unified-server">
     A unified, dynamic MCP server that provides two meta functions (tools) to discover and execute ANY functions (tools) available on ACI.dev platform.

--- a/mcp-servers/unified-server.mdx
+++ b/mcp-servers/unified-server.mdx
@@ -147,3 +147,41 @@ Once you have identified the function you need to use, you can use ACI_EXECUTE_F
     ```
   </Accordion>
 </AccordionGroup>
+
+
+## Commandline Arguments
+
+
+<AccordionGroup>
+  <Accordion title="[Optional] --allowed-apps-only">
+    The `allowed-apps-only` argument is used to limit the apps/functions (tools) search (via `ACI_SEARCH_FUNCTIONS`) to only the allowed apps that are accessible to this agent (which is identified by the `ACI_API_KEY`). If not provided (default), the `ACI_SEARCH_FUNCTIONS` will be conducted on all apps/functions available on the ACI.dev platform.
+  </Accordion>
+  <Accordion title="[Required] --linked-account-owner-id">
+    The `linked-account-owner-id` is the owner ID of the linked accounts you want to use for the function execution. E.g., `--linked-account-owner-id johndoe` means that the function execution (e.g, `GMAIL__SEND_EMAIL`) will be done on behalf of the linked account of `GMAIL` app with owner ID `johndoe`.
+  </Accordion>
+  <Accordion title="[Optional] --transport">
+    The `transport` argument is used to specify the transport protocol to use for the MCP server.
+    The default transport is `stdio`.
+  </Accordion>
+  <Accordion title="[Optional] --port">
+    The `port` argument is used to specify the port to listen on for the MCP server if the `--transport` is set to `sse`.
+    The default port is `8000`.
+  </Accordion>
+</AccordionGroup>
+
+```bash help
+$ uvx aci-mcp unified-server --help
+Usage: aci-mcp unified-server [OPTIONS]
+
+  Start the unified MCP server with unlimited tool access.
+
+Options:
+  --allowed-apps-only             Limit the functions (tools) search to only
+                                  the allowed apps that are accessible to this
+                                  agent. (identified by ACI_API_KEY)
+  --linked-account-owner-id TEXT  the owner id of the linked account to use
+                                  for the tool calls  [required]
+  --transport [stdio|sse]         Transport type
+  --port INTEGER                  Port to listen on for SSE
+  --help                          Show this message and exit.
+```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added detailed sections describing command-line arguments for both Apps MCP Server and Unified MCP Server, including usage examples and option explanations.
  - Introduced a "Comparison" section to clarify when to use each MCP server type.
  - Enhanced guidance and clarity in setup instructions and usage scenarios for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->