### PR TITLE
chore: Update ACI MCP commands to use the latest version in documentation

### DIFF
--- a/cookbooks/camel-ai.mdx
+++ b/cookbooks/camel-ai.mdx
@@ -190,7 +190,7 @@ def create_config():
             "aci_apps": {
                 "command": "uvx",
                 "args": [
-                    "aci-mcp",
+                    "aci-mcp@latest",
                     "apps-server",
                     "--apps=GITHUB",
                     "--linked-account-owner-id",

--- a/mcp-servers/apps-server.mdx
+++ b/mcp-servers/apps-server.mdx
@@ -86,7 +86,7 @@ Before using the `Apps MCP Server`, you need to complete several setup steps on 
       "mcpServers": {
         "aci-mcp-apps": {
             "command": "uvx",
-            "args": ["aci-mcp", "apps-server", "--apps", "<APP_1>,<APP_2>,...", "--linked-account-owner-id", "<LINKED_ACCOUNT_OWNER_ID>"],
+            "args": ["aci-mcp@latest", "apps-server", "--apps", "<APP_1>,<APP_2>,...", "--linked-account-owner-id", "<LINKED_ACCOUNT_OWNER_ID>"],
             "env": {
                 "ACI_API_KEY": "<ACI_API_KEY>"
             }
@@ -108,7 +108,7 @@ Before using the `Apps MCP Server`, you need to complete several setup steps on 
           "command": "bash",
           "args": [
             "-c",
-            "ACI_API_KEY=<YOUR_ACI_API_KEY> uvx aci-mcp apps-server --apps <APP_1>,<APP_2>,... --linked-account-owner-id <LINKED_ACCOUNT_OWNER_ID>"
+            "ACI_API_KEY=<YOUR_ACI_API_KEY> uvx aci-mcp@latest apps-server --apps <APP_1>,<APP_2>,... --linked-account-owner-id <LINKED_ACCOUNT_OWNER_ID>"
           ]
         }
       }
@@ -122,10 +122,10 @@ Before using the `Apps MCP Server`, you need to complete several setup steps on 
     export ACI_API_KEY=<YOUR_ACI_API_KEY>
 
     # Option 1: Run in stdio mode (default)
-    uvx aci-mcp apps-server --apps "<APP_1>,<APP_2>,..." --linked-account-owner-id <LINKED_ACCOUNT_OWNER_ID>
+    uvx aci-mcp@latest apps-server --apps "<APP_1>,<APP_2>,..." --linked-account-owner-id <LINKED_ACCOUNT_OWNER_ID>
 
     # Option 2: Run in sse mode
-    uvx aci-mcp apps-server --apps "<APP_1>,<APP_2>,..." --linked-account-owner-id <LINKED_ACCOUNT_OWNER_ID> --transport sse --port 8000
+    uvx aci-mcp@latest apps-server --apps "<APP_1>,<APP_2>,..." --linked-account-owner-id <LINKED_ACCOUNT_OWNER_ID> --transport sse --port 8000
     ```
   </Accordion>
 </AccordionGroup>
@@ -153,7 +153,7 @@ Before using the `Apps MCP Server`, you need to complete several setup steps on 
 </AccordionGroup>
 
 ```bash help
-$ uvx aci-mcp apps-server --help
+$ uvx aci-mcp@latest apps-server --help
 Usage: aci-mcp apps-server [OPTIONS]
 
   Start the apps-specific MCP server to access tools under specific apps.

--- a/mcp-servers/unified-server.mdx
+++ b/mcp-servers/unified-server.mdx
@@ -104,7 +104,7 @@ Once you have identified the function you need to use, you can use ACI_EXECUTE_F
       "mcpServers": {
         "aci-mcp-unified": {
           "command": "uvx",
-          "args": ["aci-mcp", "unified-server", "--linked-account-owner-id", "<LINKED_ACCOUNT_OWNER_ID>", "--allowed-apps-only"],
+          "args": ["aci-mcp@latest", "unified-server", "--linked-account-owner-id", "<LINKED_ACCOUNT_OWNER_ID>", "--allowed-apps-only"],
           "env": {
             "ACI_API_KEY": "<YOUR_ACI_API_KEY>"
           }
@@ -126,7 +126,7 @@ Once you have identified the function you need to use, you can use ACI_EXECUTE_F
           "command": "bash",
           "args": [
             "-c",
-            "ACI_API_KEY=<YOUR_ACI_API_KEY> uvx aci-mcp unified-server --linked-account-owner-id <LINKED_ACCOUNT_OWNER_ID> --allowed-apps-only"
+            "ACI_API_KEY=<YOUR_ACI_API_KEY> uvx aci-mcp@latest unified-server --linked-account-owner-id <LINKED_ACCOUNT_OWNER_ID> --allowed-apps-only"
           ]
         }
       }
@@ -140,10 +140,10 @@ Once you have identified the function you need to use, you can use ACI_EXECUTE_F
     export ACI_API_KEY=<YOUR_ACI_API_KEY>
 
     # Option 1: Run in stdio mode (default)
-    uvx aci-mcp unified-server --linked-account-owner-id <LINKED_ACCOUNT_OWNER_ID> --allowed-apps-only
+    uvx aci-mcp@latest unified-server --linked-account-owner-id <LINKED_ACCOUNT_OWNER_ID> --allowed-apps-only
 
     # Option 2: Run in sse mode
-    uvx aci-mcp unified-server --linked-account-owner-id <LINKED_ACCOUNT_OWNER_ID> --allowed-apps-only --transport sse --port 8000
+    uvx aci-mcp@latest unified-server --linked-account-owner-id <LINKED_ACCOUNT_OWNER_ID> --allowed-apps-only --transport sse --port 8000
     ```
   </Accordion>
 </AccordionGroup>
@@ -170,7 +170,7 @@ Once you have identified the function you need to use, you can use ACI_EXECUTE_F
 </AccordionGroup>
 
 ```bash help
-$ uvx aci-mcp unified-server --help
+$ uvx aci-mcp@latest unified-server --help
 Usage: aci-mcp unified-server [OPTIONS]
 
   Start the unified MCP server with unlimited tool access.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated all references and examples to use the latest version of the MCP server by specifying `aci-mcp@latest` in command-line instructions and configuration snippets.
  - Improved consistency across documentation for Apps MCP Server and Unified MCP Server.
  - Minor formatting adjustment with an added newline at the end of a file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->